### PR TITLE
Update releases.properties from release 2026.6.2

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,6 +1,8 @@
+12.3.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.6.2/bearsampp-mariadb-12.3.2-2026.6.2.7z
 12.2.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.3.7/bearsampp-mariadb-12.2.2-2026.3.7.7z
 12.1.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-12.1.2-2025.8.21.7z
 12.0.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.8.21/bearsampp-mariadb-12.0.2-2025.8.21.7z
+11.8.8 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.6.2/bearsampp-mariadb-11.8.8-2026.6.2.7z
 11.8.6 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.3.7/bearsampp-mariadb-11.8.6-2026.3.7.7z
 11.8.5 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-11.8.5-2025.8.21.7z
 11.8.3 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.8.21/bearsampp-mariadb-11.8.3-2025.8.21.7z
@@ -9,6 +11,7 @@
 11.6.1-RC = https://github.com/Bearsampp/module-mariadb/releases/download/2024.9.13/bearsampp-mariadb-11.6.1-RC-2024.9.13.7z
 11.5.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2024.9.13/bearsampp-mariadb-11.5.2-2024.9.13.7z
 11.5.1-RC = https://github.com/Bearsampp/module-mariadb/releases/download/2024.6.25/bearsampp-mariadb-11.5.1-RC-2024.6.25.7z
+11.4.12 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.6.2/bearsampp-mariadb-11.4.12-2026.6.2.7z
 11.4.9 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-11.4.9-2025.8.21.7z
 11.4.8 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-11.4.8-2025.8.21.7z
 11.4.7 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.7.2/bearsampp-mariadb-11.4.7-2025.7.2.7z
@@ -28,6 +31,7 @@
 11.0.6 = https://github.com/Bearsampp/module-mariadb/releases/download/2024.6.25/bearsampp-mariadb-11.0.6-2024.6.25.7z
 11.0.5 = https://github.com/Bearsampp/module-mariadb/releases/download/2024.3.31/bearsampp-mariadb-11.0.5-2024.3.31.7z
 11.0.2 = https://github.com/Bearsampp/module-mariadb/releases/download/2023.7.23/bearsampp-mariadb-11.0.2-2022.7.23.7z
+10.11.18 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.6.2/bearsampp-mariadb-10.11.18-2026.6.2.7z
 10.11.15 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-10.11.15-2025.8.21.7z
 10.11.14 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.8.21/bearsampp-mariadb-10.11.14-2025.8.21.7z
 10.11.13 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.7.2/bearsampp-mariadb-10.11.13-2025.7.2.7z
@@ -54,6 +58,7 @@
 10.8.3 = https://github.com/Bearsampp/module-mariadb/releases/download/2022.05.21/bearsampp-mariadb-10.8.3-2022.05.21.7z
 10.7.7 = https://github.com/Bearsampp/module-mariadb/releases/download/2022.12.03/bearsampp-mariadb-10.7.7-2022.12.03.7z
 10.7.6 = https://github.com/Bearsampp/module-mariadb/releases/download/2022.10.24/bearsampp-mariadb-10.7.6-2022.10.24.7z
+10.6.27 = https://github.com/Bearsampp/module-mariadb/releases/download/2026.6.2/bearsampp-mariadb-10.6.27-2026.6.2.7z
 10.6.24 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.11.22/bearsampp-mariadb-10.6.24-2025.8.21.7z
 10.6.23 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.8.21/bearsampp-mariadb-10.6.23-2025.8.21.7z
 10.6.22 = https://github.com/Bearsampp/module-mariadb/releases/download/2025.7.2/bearsampp-mariadb-10.6.22-2025.7.2.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.6.2`.

### Changes:
- Extracted .7z assets from the release
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-mariadb/releases/tag/2026.6.2

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs